### PR TITLE
Add configure options to disable progress bar

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,14 @@ AS_IF([test x$disable_startup_msg = xtrue], [
     EXTRA_GCC_FLAGS="$EXTRA_GCC_FLAGS -DPSPLASH_DISABLE_STARTUP_MSG"
 ])
 
+AC_ARG_ENABLE([progress-bar],
+    AS_HELP_STRING([--disable-progress-bar], [Disable progress bar]),
+    [disable_progress_bar=true],
+    [disable_progress_bar=false])
+AS_IF([test x$disable_progress_bar = xtrue], [
+    EXTRA_GCC_FLAGS="$EXTRA_GCC_FLAGS -DPSPLASH_DISABLE_PROGRESS_BAR"
+])
+
 AC_ARG_ENABLE([img-fullscreen],
     AS_HELP_STRING([--enable-img-fullscreen], [Enable the logo image in fullscreen mode)]),
     [img_fullscreen=true],

--- a/psplash-config.h
+++ b/psplash-config.h
@@ -21,6 +21,11 @@
 #define PSPLASH_IMG_FULLSCREEN 0
 #endif
 
+/* Bool indicated if the progress bar should be disabled */
+#ifndef PSPLASH_DISABLE_PROGRESS_BAR
+#define PSPLASH_SHOW_PROGRESS_BAR 1
+#endif
+
 /* Position of the image split from top edge, numerator of fraction */
 #define PSPLASH_IMG_SPLIT_NUMERATOR 5
 

--- a/psplash.c
+++ b/psplash.c
@@ -61,6 +61,7 @@ psplash_draw_msg (PSplashFB *fb, const char *msg)
 			msg);
 }
 
+#ifdef PSPLASH_SHOW_PROGRESS_BAR
 void
 psplash_draw_progress (PSplashFB *fb, int value)
 {
@@ -95,6 +96,7 @@ psplash_draw_progress (PSplashFB *fb, int value)
   DBG("value: %i, width: %i, barwidth :%i\n", value, 
 		width, barwidth);
 }
+#endif /* PSPLASH_SHOW_PROGRESS_BAR */
 
 static int 
 parse_command (PSplashFB *fb, char *string)
@@ -108,20 +110,22 @@ parse_command (PSplashFB *fb, char *string)
 
   command = strtok(string," ");
 
-  if (!strcmp(command,"PROGRESS")) 
-    {
-      char *arg = strtok(NULL, "\0");
-
-      if (arg)
-        psplash_draw_progress (fb, atoi(arg));
-    } 
-  else if (!strcmp(command,"MSG")) 
+  if (!strcmp(command,"MSG"))
     {
       char *arg = strtok(NULL, "\0");
 
       if (arg)
         psplash_draw_msg (fb, arg);
     } 
+ #ifdef PSPLASH_DISABLE_PROGRESS_BAR
+  else  if (!strcmp(command,"PROGRESS"))
+    {
+      char *arg = strtok(NULL, "\0");
+
+      if (arg)
+        psplash_draw_progress (fb, atoi(arg));
+    } 
+#endif
   else if (!strcmp(command,"QUIT")) 
     {
       return 1;
@@ -311,8 +315,9 @@ main (int argc, char** argv)
 			 POKY_IMG_ROWSTRIDE,
 			 POKY_IMG_RLE_PIXEL_DATA);
 
+/*#ifdef PSPLASH_SHOW_PROGRESS_BAR
   /* Draw progress bar border */
-  psplash_fb_draw_image (fb, 
+  /*psplash_fb_draw_image (fb, 
 			 (fb->width  - BAR_IMG_WIDTH)/2, 
 			 SPLIT_LINE_POS(fb),
 			 BAR_IMG_WIDTH,
@@ -322,10 +327,11 @@ main (int argc, char** argv)
 			 BAR_IMG_RLE_PIXEL_DATA);
 
   psplash_draw_progress (fb, 0);
+#endif*/
 
-#ifdef PSPLASH_STARTUP_MSG
+/*#ifdef PSPLASH_STARTUP_MSG
   psplash_draw_msg (fb, PSPLASH_STARTUP_MSG);
-#endif
+#endif*/
 
   /* Scene set so let's flip the buffers. */
   /* The first time we also synchronize the buffers so we can build on an


### PR DESCRIPTION
Progress bar can overlap with products logos, added --disable-progress-bar configure option to disable progress bar completely without patching the code.
Default behaviour is to show progress bar

Signed-off-by: Pavel Zhukov <pavel.zhukov@huawei.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>